### PR TITLE
Specify how to install Catkin.

### DIFF
--- a/prerelease_website/submit_jobs/templates/generate_command.html
+++ b/prerelease_website/submit_jobs/templates/generate_command.html
@@ -159,7 +159,7 @@
               Troubleshooting a prerelease:<h3 class="panel-title">
             </div>
             <div class="panel-body">
-              If you have trouble running <code>catkin_test_results</code> at the end of the prerelease, make sure you have catkin installed and that you've sourced your <code>setup.bash</code> file.
+              If you have trouble running <code>catkin_test_results</code> at the end of the prerelease, make sure you have <a href = "http://wiki.ros.org/catkin">catkin</a> installed and that you've sourced your <code>setup.bash</code> file.
               You can find documentation about troubleshooting prereleases that fail here:
               <a href="http://wiki.ros.org/regression_tests#What_can_I_do_when_a_prerelease_fails.3F" target="_blank">http://wiki.ros.org/regression_tests#Prerelease_Tests</a>
             </div>


### PR DESCRIPTION
> If you have trouble running catkin_test_results at the end of the prerelease, make sure you have catkin installed and that you've sourced your setup.bash file. 

I came across this issue where `catkin_test_results` wasn't found on a new machine that the message above isn't clear enough to me how to install Catkin...I think I've never explicitly installed Catkin itself.

In my case it turned out I just didn't source `setup.bash` as indicated too in the msg, but I think we don't lose anything to be clear here.