### PR TITLE
add xenial to list of prefered distros

### DIFF
--- a/prerelease_website/submit_jobs/static/js/generate_command.js
+++ b/prerelease_website/submit_jobs/static/js/generate_command.js
@@ -14,7 +14,7 @@ function load_repositories_cb(repo_list)
   var ubuntu_platforms = repo_list.release_platforms.ubuntu;
   if (ubuntu_platforms)
   {
-    var prefered_list = ['trusty'];
+    var prefered_list = ['trusty', 'xenial'];
     $.each(ubuntu_platforms, function (index, item) {
       if ($.inArray(item, prefered_list) != -1)
       {


### PR DESCRIPTION
Currently when configuring a prerelease for Kinetic the Ubuntu distros are in alphabetical order and therefore Wily is selected as a default. This should select a LTS by default instead.