### PR TITLE
make xenial the recommended os

### DIFF
--- a/prerelease_website/submit_jobs/templates/generate_command.html
+++ b/prerelease_website/submit_jobs/templates/generate_command.html
@@ -139,7 +139,7 @@
             </div>
             <div class="panel-body">
               Before running the generated command, you need to setup your system.<br/>
-              You'll find instructions for this at this website (Ubuntu 14.04 recommended):
+              You'll find instructions for this at this website (Ubuntu 16.04 recommended, Ubuntu 14.04 also supported):
               <a href="http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F" target="_blank">http://wiki.ros.org/regression_tests#Prerelease_Tests</a>
             </div>
           </div>


### PR DESCRIPTION
Tested the prerelease process on xenial and trusty. It works fine for all ubuntu version supported by the current released version of ros_buildfarm. Will also work for Yakkety and Zesty after next ros_buildfarm release