### PR TITLE
use recursive depth 0 as default

### DIFF
--- a/prerelease_website/templates/generate_command.html
+++ b/prerelease_website/templates/generate_command.html
@@ -91,7 +91,7 @@
         <form>
           <div class="form-group">
             <label for="rdepends_level">Recursive dependency level:</label>
-            <input class="aSpinEdit" type="text" value="1" id="rdepends_level" />
+            <input class="aSpinEdit" type="text" value="0" id="rdepends_level" />
           </div>
           <div class="form-group">
             <label for="dependents_to_be_built">Dependents to test:</label>


### PR DESCRIPTION
Until #33 is actually fixed this at least uses a default which doesn't prevent the usage for repositories with a lot of dependencies.