### PR TITLE
Add an error message for unknown ROS distributions.

### DIFF
--- a/prerelease_website/__init__.py
+++ b/prerelease_website/__init__.py
@@ -7,6 +7,7 @@ from flask import render_template
 from .ajax import get_package_list_for_remote_repo_ajax
 from .ajax import get_rdepends_by_level_and_excludes_ajax
 from .ajax import get_repo_list_ajax
+from .ajax import check_distro_ajax
 
 app = Flask(__name__)
 
@@ -18,7 +19,10 @@ def index():
 
 @app.route('/<distro>')
 def distro(distro):
-    return render_template('generate_command.html', distro=distro)
+    if check_distro_ajax(distro):
+        return render_template('generate_command.html', distro=distro)
+    else:
+        return render_template('404.html', distro=distro), 404
 
 
 @app.route('/get_repo_list/<distro>')

--- a/prerelease_website/ajax.py
+++ b/prerelease_website/ajax.py
@@ -11,7 +11,6 @@ import rospkg
 import vcstools
 import yaml
 
-from .models import DryRosDistro
 from .models import WetRosDistro
 
 logger = logging.getLogger('prerelease')
@@ -45,10 +44,6 @@ def check_distro_ajax(ros_distro):
 
 
 def get_repo_list_ajax(ros_distro):
-    dry_distro = DryRosDistro(ros_distro)
-    repo_list = dry_distro.get_info()
-    logger.info("Got dry repo list")
-
     try:
         wet_distro = WetRosDistro(ros_distro)
     except Exception as e:
@@ -57,11 +52,10 @@ def get_repo_list_ajax(ros_distro):
             'message': str(e),
         })
 
+    repo_list = {}
     for name, d in wet_distro.get_info().items():
-        if name in repo_list:
-            logger.info("%s is in both wet and dry rosdistro!!!!" % name)
-        else:
-            repo_list[name] = d
+        repo_list[name] = d
+
     logger.info("Got wet repo list")
 
     return json.dumps({

--- a/prerelease_website/ajax.py
+++ b/prerelease_website/ajax.py
@@ -36,12 +36,27 @@ class temporary_directory(object):
             os.chdir(self.original_cwd)
 
 
+def check_distro_ajax(ros_distro):
+    try:
+        wet_distro = WetRosDistro(ros_distro)
+        return True
+    except Exception as e:
+        return False
+
+
 def get_repo_list_ajax(ros_distro):
     dry_distro = DryRosDistro(ros_distro)
     repo_list = dry_distro.get_info()
     logger.info("Got dry repo list")
 
-    wet_distro = WetRosDistro(ros_distro)
+    try:
+        wet_distro = WetRosDistro(ros_distro)
+    except Exception as e:
+        return json.dumps({
+            'status': 500,
+            'message': str(e),
+        })
+
     for name, d in wet_distro.get_info().items():
         if name in repo_list:
             logger.info("%s is in both wet and dry rosdistro!!!!" % name)

--- a/prerelease_website/models.py
+++ b/prerelease_website/models.py
@@ -49,8 +49,8 @@ class WetRosDistro(object):
             index = get_index(get_index_url())
             self._distribution_file = get_distribution_cache(index, distro).distribution_file
         except:
-            logger.error("Could not load rosdistro distribution cache")
-            self._distribution_file = None
+            logger.error("Could not load rosdistro distribution cache for '%s'" % (distro))
+            raise
 
     def get_release_platforms(self):
         return self._distribution_file.release_platforms

--- a/prerelease_website/models.py
+++ b/prerelease_website/models.py
@@ -6,32 +6,6 @@ import rospkg.distro
 logger = logging.getLogger('prerelease')
 
 
-class DryRosDistro(object):
-    def __init__(self, distro):
-        self.distro = distro
-        if distro == 'groovy':
-            self.distro_obj = rospkg.distro.load_distro(rospkg.distro.distro_uri(distro))
-        else:
-            self.distro_obj = None
-
-    def get_info(self):
-        res = {}
-        if not self.distro_obj:
-            return res
-        for name, s in self.distro_obj.stacks.iteritems():
-            if s.vcs_config.type == 'svn':
-                url = s.vcs_config.anon_dev
-                branch = ""
-            else:
-                url = s.vcs_config.repo_uri
-                branch = s.vcs_config.dev_branch
-            res[name] = {'distro': self.distro + "_dry",
-                         'version': ["devel"],
-                         'url': [url],
-                         'branch': [branch]}
-        return res
-
-
 def has_release(repo):
     return getattr(repo, 'release_repository', None) is not None
 

--- a/prerelease_website/templates/404.html
+++ b/prerelease_website/templates/404.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Page Not Found{% endblock %}
+{% block content %}
+  <h1>Page Not Found</h1>
+  <p>Unknown ROS distribution '{{ distro }}'.
+  <p><a href="{{ url_for('index') }}">Back to the main page</a>
+{% endblock %}


### PR DESCRIPTION
This adds a 404 for unknown ROS distributions rather than a
page that just doesn't work.

Fixes https://github.com/ros-infrastructure/prerelease_website/issues/22

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>