### PR TITLE
replace vcstools with vcstool

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ pip install -U Flask
 Install the domain (ROS) specific dependencies:
 
 ```
-$ pip install -U ros_buildfarm rosinstall_generator vcstools
+$ pip install -U ros_buildfarm rosinstall_generator vcstool
 ```
 
 Running Locally


### PR DESCRIPTION
`vcstools` is not actively maintained and this is the last piece of infrastructure using it. This patch replaces the API calls with `vcstool` which is actively maintained and being used in the current ROS instructions.